### PR TITLE
fix for windows compatibility

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -1,5 +1,5 @@
 import json
-import os
+import posixpath 
 import requests
 from collections import OrderedDict
 
@@ -40,14 +40,14 @@ def create_payload(data):
 class Airtable(object):
     def __init__(self, base_id, api_key):
         self.airtable_url = API_URL % API_VERSION
-        self.base_url = os.path.join(self.airtable_url, base_id)
+        self.base_url = posixpath.join(self.airtable_url, base_id)
         self.headers = {'Authorization': 'Bearer %s' % api_key}
 
     def __request(self, method, url, params=None, payload=None):
         if method in ['POST', 'PUT', 'PATCH']:
             self.headers.update({'Content-type': 'application/json'})
         r = requests.request(method,
-                             os.path.join(self.base_url, url),
+                             posixpath.join(self.base_url, url),
                              params=params,
                              data=payload,
                              headers=self.headers)
@@ -68,7 +68,7 @@ class Airtable(object):
             filter_by_formula=None, view=None):
         params = {}
         if check_string(record_id):
-            url = os.path.join(table_name, record_id)
+            url = posixpath.join(table_name, record_id)
         else:
             url = table_name
             if limit and check_integer(limit):
@@ -123,19 +123,19 @@ class Airtable(object):
 
     def update(self, table_name, record_id, data):
         if check_string(table_name) and check_string(record_id):
-            url = os.path.join(table_name, record_id)
+            url = posixpath.join(table_name, record_id)
             payload = create_payload(data)
             return self.__request('PATCH', url,
                                   payload=json.dumps(payload))
 
     def update_all(self, table_name, record_id, data):
         if check_string(table_name) and check_string(record_id):
-            url = os.path.join(table_name, record_id)
+            url = posixpath.join(table_name, record_id)
             payload = create_payload(data)
             return self.__request('PUT', url,
                                   payload=json.dumps(payload))
 
     def delete(self, table_name, record_id):
         if check_string(table_name) and check_string(record_id):
-            url = os.path.join(table_name, record_id)
+            url = posixpath.join(table_name, record_id)
             return self.__request('DELETE', url)

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,9 @@ setup(
     version='0.3.1',
     packages=['airtable'],
     install_requires=['requests>=2.5.3'],
+    description='Python client library for AirTable',
+    author='Nicolo Canali De Rossi, Pascal Corpet',
+    url='https://github.com/bayesimpact/airtable-python',
+    keywords=['airtable', 'api'],
+    license='The MIT License (MIT)',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name='airtable',
-    version='0.2.0',
+    version='0.3.0',
     packages=['airtable'],
     install_requires=['requests>=2.5.3'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name='airtable',
-    version='0.3.0',
+    version='0.3.1',
     packages=['airtable'],
     install_requires=['requests>=2.5.3'],
 )

--- a/test_airtable.py
+++ b/test_airtable.py
@@ -128,6 +128,32 @@ class TestAirtable(unittest.TestCase):
         r = self.airtable.get(FAKE_TABLE_NAME, '123')
         self.assertEqual(r['error']['code'], 404)
 
+    @mock.patch.object(requests, 'request')
+    def test_get_view(self, mock_request):
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'records': []}
+        mock_request.return_value = mock_response
+
+        r = self.airtable.get(FAKE_TABLE_NAME, view='My view')
+        mock_request.assert_called_once_with(
+            'GET', 'https://api.airtable.com/v0/app12345/TableName',
+            data=None, headers={'Authorization': 'Bearer fake_api_key'},
+            params={'view': 'My view'})
+
+    @mock.patch.object(requests, 'request')
+    def test_get_filter_by_formula(self, mock_request):
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'records': []}
+        mock_request.return_value = mock_response
+
+        r = self.airtable.get(FAKE_TABLE_NAME, filter_by_formula="{title} = ''")
+        mock_request.assert_called_once_with(
+            'GET', 'https://api.airtable.com/v0/app12345/TableName',
+            data=None, headers={'Authorization': 'Bearer fake_api_key'},
+            params={'filterByFormula': "{title} = ''"})
+
     def test_invalid_get(self):
         with self.assertRaises(airtable.IsNotString):
             self.airtable.get(FAKE_TABLE_NAME, 123)


### PR DESCRIPTION
os.path.join() will not generate the correct URLs on Windows.
By replacing the calls with posixpath.join(), it should work on all systems.