### PR TITLE
Fix compatibility with python 3.x

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -58,7 +58,7 @@ class Airtable(object):
                 message = None
                 r.raise_for_status()
             except requests.exceptions.HTTPError as e:
-                message = e.message
+                message = str(e)
             return {
                 'error': dict(code=r.status_code, message=message)
             }

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name='airtable',
-    version='0.3.1',
+    version='0.3.2',
     packages=['airtable'],
     install_requires=['requests>=2.5.3'],
     description='Python client library for AirTable',


### PR DESCRIPTION
BaseException.message was deprecated in 2.6 and throws an error.